### PR TITLE
Show all available subtitles for each language - sorted by similarity to the movie name

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -12,7 +12,7 @@ def pods
     pod 'SwiftyTimer', '~> 2.0.0'
     pod 'FloatRatingView', '~> 2.0.1'
     pod 'Reachability', :git => 'https://github.com/tonymillion/Reachability'
-    pod 'MarqueeLabel/Swift', '~> 3.0.3'
+    pod 'MarqueeLabel', '~> 3.0.3'
     pod 'ObjectMapper', '~> 2.2.6'
 end
 

--- a/PopcornKit/Managers/GoogleCastManager.swift
+++ b/PopcornKit/Managers/GoogleCastManager.swift
@@ -4,7 +4,7 @@
     import Foundation
     import GoogleCast
     
-    public typealias CastMetaData = (title: String, image: URL?, contentType: String, subtitles: [Subtitle]?, url: String, mediaAssetsPath: URL, startPosition: TimeInterval)
+    public typealias CastMetaData = (title: String, image: URL?, contentType: String, subtitles: [String: [Subtitle]]?, url: String, mediaAssetsPath: URL, startPosition: TimeInterval)
     
     public enum TableViewUpdates {
         case reload

--- a/PopcornKit/Managers/SubtitlesManager.swift
+++ b/PopcornKit/Managers/SubtitlesManager.swift
@@ -24,10 +24,10 @@ open class SubtitlesManager: NetworkManager {
      
      - Parameter completion:    Completion handler called with array of subtitles and an optional error.
      */
-    open func search(_ episode: Episode? = nil, imdbId: String? = nil, limit: String = "300", completion:@escaping ([Subtitle], NSError?) -> Void) {
+    open func search(_ episode: Episode? = nil, imdbId: String? = nil, limit: String = "300", completion:@escaping ([String: [Subtitle]], NSError?) -> Void) {
         guard let token = token else {
             login() { error in
-                guard error == nil else { completion([], error); return }
+                guard error == nil else { completion([:], error); return }
                 self.search(episode, imdbId: imdbId, limit: limit, completion: completion)
             }
             return
@@ -46,23 +46,39 @@ open class SubtitlesManager: NetworkManager {
             guard let value = response.result.value,
                 let status = value[0]["status"].string?.components(separatedBy: " ").first,
                 let data = value[0]["data"].array,
-                response.result.isSuccess && status == "200" else { DispatchQueue.main.async(execute: {completion([], response.result.error as NSError?)}); return}
-            var subtitles = [Subtitle]()
+                response.result.isSuccess && status == "200" else { DispatchQueue.main.async(execute: {completion([:], response.result.error as NSError?)}); return}
+            var subtitles = [String: [Subtitle]]()
             for info in data {
                 guard
                     let subDownloadLink = info["SubDownloadLink"].string,
+                    let subFileName = info["MovieReleaseName"].string,
+                    let movieName = info["MovieName"].string,
+                    let subCleanFileName = self.cleanSubName(subFileName, byMovieName: movieName),
                     let ISO639 = info["ISO639"].string,
-                    let localizedLanguageName = Locale.current.localizedString(forLanguageCode: ISO639)?.localizedCapitalized,
-                    !subtitles.contains(where: {$0.language == localizedLanguageName})
+                    let localizedLanguageName = Locale.current.localizedString(forLanguageCode: ISO639)?.localizedCapitalized
                     else {
                         continue
                 }
-                
-                subtitles.append(Subtitle(language: localizedLanguageName, link: subDownloadLink, ISO639: ISO639))
+                var langSubtitles = subtitles[ISO639] ?? [Subtitle]()
+                langSubtitles.append(Subtitle(language: localizedLanguageName, link: subDownloadLink, name: subFileName, cleanName: subCleanFileName, ISO639: ISO639))
+                subtitles[ISO639] = langSubtitles
             }
-            subtitles.sort(by: { $0.language < $1.language })
             DispatchQueue.main.async(execute: { completion(subtitles, nil) })
         })
+    }
+    
+    private func cleanSubName(_ subName: String, byMovieName movieName: String) -> String? {
+        let subNameParts = subName.components(separatedBy: CharacterSet.alphanumerics.inverted).filter { (part) -> Bool in
+            part != ""
+        }
+        let movieNameParts = movieName.components(separatedBy: CharacterSet.alphanumerics.inverted).filter { (part) -> Bool in
+            part != ""
+        }
+        var i = 0
+        while subNameParts[i] == movieNameParts[i] {
+            i += 1
+        }
+        return subNameParts[i...subNameParts.count - 1].joined(separator: " ")
     }
     
     /**

--- a/PopcornKit/Managers/SubtitlesManager.swift
+++ b/PopcornKit/Managers/SubtitlesManager.swift
@@ -59,9 +59,9 @@ open class SubtitlesManager: NetworkManager {
                     else {
                         continue
                 }
-                var langSubtitles = subtitles[ISO639] ?? [Subtitle]()
+                var langSubtitles = subtitles[localizedLanguageName] ?? [Subtitle]()
                 langSubtitles.append(Subtitle(language: localizedLanguageName, link: subDownloadLink, name: subFileName, cleanName: subCleanFileName, ISO639: ISO639))
-                subtitles[ISO639] = langSubtitles
+                subtitles[localizedLanguageName] = langSubtitles
             }
             DispatchQueue.main.async(execute: { completion(subtitles, nil) })
         })

--- a/PopcornKit/Models/Episode.swift
+++ b/PopcornKit/Models/Episode.swift
@@ -68,7 +68,7 @@ public struct Episode: Media, Equatable {
     public var torrents = [Torrent]()
     
     /// The subtitles associated with the episode. Empty by default. Must be filled by calling `search:episode:imdbId:limit:completion:` on `SubtitlesManager`.
-    public var subtitles = [Subtitle]()
+    public var subtitles = [String: [Subtitle]]()
     
     public init?(map: Map) {
         do { self = try Episode(map) }
@@ -104,7 +104,7 @@ public struct Episode: Media, Equatable {
         self.largeBackgroundImage = try? map.value("images.fanart")
     }
     
-    public init(title: String = "Unknown".localized, id: String = "0000000", tmdbId: Int? = nil, slug: String = "unknown", summary: String = "No summary available.".localized, torrents: [Torrent] = [], subtitles: [Subtitle] = [], largeBackgroundImage: String? = nil, largeCoverImage: String? = nil) {
+    public init(title: String = "Unknown".localized, id: String = "0000000", tmdbId: Int? = nil, slug: String = "unknown", summary: String = "No summary available.".localized, torrents: [Torrent] = [], subtitles: [String: [Subtitle]] = [:], largeBackgroundImage: String? = nil, largeCoverImage: String? = nil) {
         self.title = title
         self.id = id
         self.tmdbId = tmdbId

--- a/PopcornKit/Models/Media.swift
+++ b/PopcornKit/Models/Media.swift
@@ -20,7 +20,7 @@ public protocol Media: Mappable {
     var largeCoverImage: String? { get set }
     
     /// Will be empty if Media is Show.
-    var subtitles: [Subtitle] { get set }
+    var subtitles: [String: [Subtitle]] { get set }
     
     /// Will be empty if Media is Show.
     var torrents: [Torrent] { get set }
@@ -31,13 +31,13 @@ public protocol Media: Mappable {
     /// Will return `false` if Media is Episode.
     var isAddedToWatchlist: Bool { get set }
     
-    init(title: String, id: String, tmdbId: Int?, slug: String, summary: String, torrents: [Torrent], subtitles: [Subtitle], largeBackgroundImage: String?, largeCoverImage: String?)
+    init(title: String, id: String, tmdbId: Int?, slug: String, summary: String, torrents: [Torrent], subtitles: [String: [Subtitle]], largeBackgroundImage: String?, largeCoverImage: String?)
 }
 
 // MARK: - Optional vars
 
 extension Media {
-    public var subtitles: [Subtitle] { get { return [] } set {} }
+    public var subtitles: [String: [Subtitle]] { get { return [:] } set {} }
     public var torrents: [Torrent] { get { return [] } set {} }
     
     public var isWatched: Bool { get { return false } set {} }

--- a/PopcornKit/Models/Movie.swift
+++ b/PopcornKit/Models/Movie.swift
@@ -110,7 +110,7 @@ public struct Movie: Media, Equatable {
     public var torrents = [Torrent]()
     
     /// The subtitles associated with the movie. Empty by default. Must be filled by calling `search:episode:imdbId:limit:completion:` on `SubtitlesManager`.
-    public var subtitles = [Subtitle]()
+    public var subtitles = [String: [Subtitle]]()
     
     /// The genres associated with the movie.
     public var genres = [String]()
@@ -156,7 +156,7 @@ public struct Movie: Media, Equatable {
         torrents.sort(by: <)
     }
     
-    public init(title: String = "Unknown".localized, id: String = "tt0000000", tmdbId: Int? = nil, slug: String = "unknown", summary: String = "No summary available.".localized, torrents: [Torrent] = [], subtitles: [Subtitle] = [], largeBackgroundImage: String? = nil, largeCoverImage: String? = nil) {
+    public init(title: String = "Unknown".localized, id: String = "tt0000000", tmdbId: Int? = nil, slug: String = "unknown", summary: String = "No summary available.".localized, torrents: [Torrent] = [], subtitles: [String: [Subtitle]] = [:], largeBackgroundImage: String? = nil, largeCoverImage: String? = nil) {
         self.title = title
         self.id = id
         self.tmdbId = tmdbId

--- a/PopcornKit/Models/Show.swift
+++ b/PopcornKit/Models/Show.swift
@@ -157,7 +157,7 @@ public struct Show: Media, Equatable {
         self.episodes.sort(by: { $0.episode < $1.episode })
     }
     
-    public init(title: String = "Unknown".localized, id: String = "tt0000000", tmdbId: Int? = nil, slug: String = "unknown", summary: String = "No summary available.".localized, torrents: [Torrent] = [], subtitles: [Subtitle] = [], largeBackgroundImage: String? = nil, largeCoverImage: String? = nil) {
+    public init(title: String = "Unknown".localized, id: String = "tt0000000", tmdbId: Int? = nil, slug: String = "unknown", summary: String = "No summary available.".localized, torrents: [Torrent] = [], subtitles: [String: [Subtitle]] = [:], largeBackgroundImage: String? = nil, largeCoverImage: String? = nil) {
         self.title = title
         self.id = id
         self.tmdbId = tmdbId

--- a/PopcornKit/Models/Subtitle.swift
+++ b/PopcornKit/Models/Subtitle.swift
@@ -11,14 +11,21 @@ public struct Subtitle: Equatable {
     public let language: String
     /// Link to the subtitle zip.
     public let link: String
+    // Name of the subtitle file
+    public let name: String
+    // Name of the subtitle file without movie name
+    public let cleanName: String
     /// Two letter ISO language code of the subtitle eg. en.
     public let ISO639: String
     
-    public init(language: String, link: String, ISO639: String) {
+    public init(language: String, link: String, name: String, cleanName: String, ISO639: String) {
         self.language = language
         self.link = link
+        self.name = name
         self.ISO639 = ISO639
+        self.cleanName = cleanName
     }
+    
 }
 
 public func ==(lhs: Subtitle, rhs: Subtitle) -> Bool {

--- a/PopcornTime/Base.lproj/tvOS.storyboard
+++ b/PopcornTime/Base.lproj/tvOS.storyboard
@@ -2199,21 +2199,21 @@
                                 <rect key="frame" x="0.0" y="0.0" width="1536" height="260"/>
                                 <subviews>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="36" sectionHeaderHeight="66" sectionFooterHeight="66" translatesAutoresizingMaskIntoConstraints="NO" id="UlS-mm-fbC">
-                                        <rect key="frame" x="0.0" y="0.0" width="390" height="260"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="750" height="260"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="390" id="FJ7-Ho-EYX"/>
+                                            <constraint firstAttribute="width" constant="750" id="FJ7-Ho-EYX"/>
                                         </constraints>
                                         <prototypes>
-                                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" accessoryType="checkmark" indentationWidth="10" reuseIdentifier="cell" focusStyle="custom" textLabel="Bgz-fM-GuE" style="IBUITableViewCellStyleDefault" id="eUc-ua-lyY">
-                                                <rect key="frame" x="0.0" y="66" width="390" height="36"/>
+                                            <tableViewCell contentMode="scaleToFill" misplaced="YES" selectionStyle="none" accessoryType="checkmark" indentationWidth="10" reuseIdentifier="cell" focusStyle="custom" textLabel="Bgz-fM-GuE" style="IBUITableViewCellStyleDefault" id="eUc-ua-lyY">
+                                                <rect key="frame" x="0.0" y="66" width="750" height="36"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="eUc-ua-lyY" id="DKU-4V-qYv">
-                                                    <rect key="frame" x="0.0" y="0.0" width="301" height="36"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="661" height="36"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <subviews>
                                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Bgz-fM-GuE">
-                                                            <rect key="frame" x="20" y="0.0" width="281" height="36"/>
+                                                            <rect key="frame" x="20" y="0.0" width="641" height="36"/>
                                                             <autoresizingMask key="autoresizingMask"/>
                                                             <fontDescription key="fontDescription" type="system" weight="medium" pointSize="31"/>
                                                             <color key="textColor" white="1" alpha="0.5" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -2229,21 +2229,21 @@
                                         </connections>
                                     </tableView>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="36" sectionHeaderHeight="66" sectionFooterHeight="66" translatesAutoresizingMaskIntoConstraints="NO" id="9d3-DW-N0d">
-                                        <rect key="frame" x="518" y="0.0" width="390" height="260"/>
+                                        <rect key="frame" x="768" y="0.0" width="250" height="260"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="390" id="q8P-sr-5nc"/>
+                                            <constraint firstAttribute="width" constant="250" id="q8P-sr-5nc"/>
                                         </constraints>
                                         <prototypes>
-                                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" accessoryType="checkmark" indentationWidth="10" reuseIdentifier="cell" focusStyle="custom" textLabel="O2t-15-u5G" style="IBUITableViewCellStyleDefault" id="6yY-iV-y03">
-                                                <rect key="frame" x="0.0" y="66" width="390" height="36"/>
+                                            <tableViewCell contentMode="scaleToFill" misplaced="YES" selectionStyle="none" accessoryType="checkmark" indentationWidth="10" reuseIdentifier="cell" focusStyle="custom" textLabel="O2t-15-u5G" style="IBUITableViewCellStyleDefault" id="6yY-iV-y03">
+                                                <rect key="frame" x="0.0" y="66" width="250" height="36"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="6yY-iV-y03" id="fnx-UA-OnZ">
-                                                    <rect key="frame" x="0.0" y="0.0" width="301" height="36"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="161" height="36"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <subviews>
                                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="O2t-15-u5G">
-                                                            <rect key="frame" x="20" y="0.0" width="281" height="36"/>
+                                                            <rect key="frame" x="20" y="0.0" width="141" height="36"/>
                                                             <autoresizingMask key="autoresizingMask"/>
                                                             <fontDescription key="fontDescription" type="system" weight="medium" pointSize="31"/>
                                                             <color key="textColor" white="1" alpha="0.5" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/PopcornTime/Extensions/Media+Extension.swift
+++ b/PopcornTime/Extensions/Media+Extension.swift
@@ -111,7 +111,7 @@ extension Media {
      
      - Parameter completion: The completion handler for the request containing an array of subtitles
      */
-    func getSubtitles(forId id: String, completion: @escaping ([Subtitle]) -> Void) {
+    func getSubtitles(forId id: String, completion: @escaping ([String: [Subtitle]]) -> Void) {
         if let `self` = self as? Episode, !id.hasPrefix("tt") {
             TraktManager.shared.getEpisodeMetadata(self.show.id, episodeNumber: self.episode, seasonNumber: self.season, completion: { (episode, _) in
                 if let imdb = episode?.imdbId { self.getSubtitles(forId: imdb, completion: completion) } else {

--- a/PopcornTime/UI/Shared/View Controllers/PCTPlayerViewController.swift
+++ b/PopcornTime/UI/Shared/View Controllers/PCTPlayerViewController.swift
@@ -193,7 +193,7 @@ class PCTPlayerViewController: UIViewController, VLCMediaPlayerDelegate, UIGestu
     // MARK: - Public vars
     
     weak var delegate: PCTPlayerViewControllerDelegate?
-    var subtitles: [Subtitle] {
+    var subtitles: [String: [Subtitle]] {
         return media.subtitles
     }
     var currentSubtitle: Subtitle? {
@@ -323,7 +323,7 @@ class PCTPlayerViewController: UIViewController, VLCMediaPlayerDelegate, UIGestu
         (mediaplayer as VLCFontAppearance).setTextRendererFont!(settings.font.fontName as NSString)
         (mediaplayer as VLCFontAppearance).setTextRendererFontForceBold!(NSNumber(booleanLiteral: settings.style == .bold || settings.style == .boldItalic))
         if let preferredLanguage = settings.language {
-            currentSubtitle = subtitles.first(where: {$0.language == preferredLanguage})
+            currentSubtitle = subtitles[preferredLanguage]?.first
         }
         mediaplayer.media.addOptions([vlcSettingTextEncoding: settings.encoding])
 

--- a/PopcornTime/UI/iOS/Table View Controllers/OptionsTableViewController.swift
+++ b/PopcornTime/UI/iOS/Table View Controllers/OptionsTableViewController.swift
@@ -15,7 +15,7 @@ class OptionsTableViewController: UITableViewController {
     
     weak var delegate: OptionsViewControllerDelegate?
     
-    var subtitles = [Subtitle]()
+    var subtitles = [String: [Subtitle]]()
     
     var currentSubtitle: Subtitle?
     var currentSubtitleDelay = 0

--- a/PopcornTime/UI/tvOS/Option View Controllers/SubtitlesViewController.swift
+++ b/PopcornTime/UI/tvOS/Option View Controllers/SubtitlesViewController.swift
@@ -80,7 +80,7 @@ class SubtitlesViewController: OptionsStackViewController, UITableViewDataSource
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         switch tableView {
         case firstTableView:
-            return sortedSubtitles[subtitleLangs[section]]?.first?.language
+            return subtitleLangs[section]
         case secondTableView:
             return "Delay".localized
         case thirdTableView:


### PR DESCRIPTION
Currently, the first subtitle is always selected, even if it isn't in sync with the movie itself... This shows all the available subtitles so the user can choose which subtitle to use, and order them by the similarity to the name of the video file (this depends on a PR to PopcornTorrent).