### PR TITLE
Fix for French translation - Text was too long

### DIFF
--- a/PopcornTime/fr.lproj/tvOS.strings
+++ b/PopcornTime/fr.lproj/tvOS.strings
@@ -126,7 +126,7 @@
 
 // MARK: - UpNextViewController titles
 
-"wUm-fX-3pb.normalTitle" = "Regarder l'épisode suivant";
+"wUm-fX-3pb.normalTitle" = "Épisode suivant";
 "1P4-1O-ZA3.normalTitle" = "Retourner à la vidéo";
 
 // MARK: - LoadExternalTorrentViewController title


### PR DESCRIPTION
I'm actually fixing my pull request #630, in the Up Next screen, the French title for the Next button was too long and got ellipsis in the middle of the text.
No other major issue found.