### PR TITLE
Fix DownloadButton Enum issues in IOS 12

### DIFF
--- a/PopcornTime/UI/Shared/Views/DownloadButton.swift
+++ b/PopcornTime/UI/Shared/Views/DownloadButton.swift
@@ -11,7 +11,7 @@ import enum PopcornTorrent.PTTorrentDownloadStatus
     
 class DownloadButton: UIDownloadButton, UIGestureRecognizerDelegate {
     
-    enum State {
+    enum Status {
         case downloading
         case paused
         case pending
@@ -34,7 +34,7 @@ class DownloadButton: UIDownloadButton, UIGestureRecognizerDelegate {
         }
     }
     
-    var downloadState: State = .normal {
+    var downloadState: Status = .normal {
         didSet {
             guard downloadState != oldValue else { return }
             

--- a/PopcornTime/UI/tvOS/Collection View Cells/DownloadDetailCollectionViewCell.swift
+++ b/PopcornTime/UI/tvOS/Collection View Cells/DownloadDetailCollectionViewCell.swift
@@ -15,7 +15,7 @@ class DownloadCollectionViewCell: BaseCollectionViewCell {
     @IBOutlet var pausedImageView: UIImageView!
     
     
-    var downloadState: DownloadButton.State = .normal {
+    var downloadState: DownloadButton.Status = .normal {
         didSet {
             guard downloadState != oldValue else { return }
             
@@ -63,7 +63,7 @@ extension DownloadCollectionViewCell: CellCustomizing {
         guard let download = item as? PTTorrentDownload else { print(">>> initializing cell with invalid item"); return }
 
         self.progress = download.torrentStatus.totalProgress
-        self.downloadState = DownloadButton.State(download.downloadStatus)
+        self.downloadState = DownloadButton.Status(download.downloadStatus)
 
         if let image = download.mediaMetadata[MPMediaItemPropertyArtwork] as? String, let url = URL(string: image) {
             self.imageView?.af_setImage(withURL: url)

--- a/PopcornTime/UI/tvOS/Collection View Controllers/EpisodesViewController.swift
+++ b/PopcornTime/UI/tvOS/Collection View Controllers/EpisodesViewController.swift
@@ -134,7 +134,7 @@ class EpisodesViewController: UIViewController, UICollectionViewDataSource, UICo
     func downloadStatusDidChange(_ downloadStatus: PTTorrentDownloadStatus, for download: PTTorrentDownload) {
         guard let media = dataSource[safe: focusIndexPath.row],
             download == media.associatedDownload else { return }
-        downloadButton.downloadState = DownloadButton.State(downloadStatus)
+        downloadButton.downloadState = DownloadButton.Status(downloadStatus)
     }
     
     func downloadDidFail(_ download: PTTorrentDownload, withError error: Error) {
@@ -235,7 +235,7 @@ class EpisodesViewController: UIViewController, UICollectionViewDataSource, UICo
             focusIndexPath = next
             
             let downloadStatus = episode.associatedDownload?.downloadStatus ?? .failed
-            downloadButton.downloadState = DownloadButton.State(downloadStatus)
+            downloadButton.downloadState = DownloadButton.Status(downloadStatus)
             downloadButton.progress = episode.associatedDownload?.torrentStatus.totalProgress ?? 0
             
             episodeSummaryTextView.text = episode.summary

--- a/PopcornTime/UI/tvOS/View Controllers/DownloadViewController+tvOS.swift
+++ b/PopcornTime/UI/tvOS/View Controllers/DownloadViewController+tvOS.swift
@@ -166,7 +166,7 @@ extension DownloadViewController: CollectionViewControllerDelegate, DownloadColl
         
         if let download = item as? PTTorrentDownload {
             let button = DownloadButton()
-            button.downloadState = DownloadButton.State(download.downloadStatus)
+            button.downloadState = DownloadButton.Status(download.downloadStatus)
             
             AppDelegate.shared.downloadButton(button, wasPressedWith: download) { [unowned self] in
                 self.reloadData()


### PR DESCRIPTION
I have renamed the `Enum State` to `Enum Status` in DownloadButton.swift, and updated the 3 files with references to it. This is because on IOS 12 there a conflict within UIKit for Status. 