### PR TITLE
fixed blinked Alert tvos13

### DIFF
--- a/PopcornTime/Extensions/UIAlertController+Show.swift
+++ b/PopcornTime/Extensions/UIAlertController+Show.swift
@@ -4,13 +4,32 @@ import Foundation
 import UIKit.UIAlertController
 
 extension UIAlertController {
+
+    private struct AssociatedKey {
+       static var window:   UInt8 = 0
+    }
+
+    var window: UIWindow? {
+        get {
+          return objc_getAssociatedObject(self, &AssociatedKey.window) as? UIWindow
+        }
+        set {
+            objc_setAssociatedObject(self, &AssociatedKey.window, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+
+    open override func viewDidDisappear(_ animated: Bool) {
+      super.viewDidDisappear(animated)
+      window?.isHidden = true
+      window = nil
+    }
     
     func show(animated flag: Bool, completion: (() -> Void)? = nil) {
-        let window = UIWindow(frame: UIScreen.main.bounds)
-        window.rootViewController = UIViewController()
-        window.windowLevel = UIWindow.Level.alert
-        window.makeKeyAndVisible()
-        window.tintColor = .app
-        window.rootViewController!.present(self, animated: flag, completion: completion)
+        self.window = UIWindow(frame: UIScreen.main.bounds)
+        window?.rootViewController = UIViewController()
+        window?.windowLevel = UIWindow.Level.alert
+        window?.makeKeyAndVisible()
+        window?.tintColor = .app
+        window?.rootViewController!.present(self, animated: flag, completion: completion)
     }
 }


### PR DESCRIPTION
in the case of several files in the external magnet link, it was not possible to select the necessary file and the screen was locked in the "hold" state.