### PR TITLE
Fixing multiple position issues on Download Detail screen

### DIFF
--- a/PopcornTime/Base.lproj/tvOS.storyboard
+++ b/PopcornTime/Base.lproj/tvOS.storyboard
@@ -1871,7 +1871,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="Cell" textLabel="gPE-3j-CJL" detailTextLabel="tTB-eB-9BY" style="IBUITableViewCellStyleValue1" id="2pA-rv-1hD">
-                                        <rect key="frame" x="0.0" y="673" width="730" height="66"/>
+                                        <rect key="frame" x="110" y="673" width="730" height="66"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="2pA-rv-1hD" id="LN9-i5-qD9">
                                             <rect key="frame" x="0.0" y="0.0" width="730" height="66"/>
@@ -1895,7 +1895,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="Cell" textLabel="5WO-YN-RUa" detailTextLabel="0rw-Qu-Rs6" style="IBUITableViewCellStyleValue1" id="lz1-xx-sNH">
-                                        <rect key="frame" x="0.0" y="753" width="730" height="66"/>
+                                        <rect key="frame" x="110" y="753" width="730" height="66"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="lz1-xx-sNH" id="y1f-F9-CNt">
                                             <rect key="frame" x="0.0" y="0.0" width="730" height="66"/>
@@ -1919,7 +1919,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="Cell" textLabel="f8x-Ym-rQl" detailTextLabel="Aud-tf-JFq" style="IBUITableViewCellStyleValue1" id="kJS-hT-WnH">
-                                        <rect key="frame" x="0.0" y="833" width="730" height="66"/>
+                                        <rect key="frame" x="110" y="833" width="730" height="66"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="kJS-hT-WnH" id="ldq-w5-55A">
                                             <rect key="frame" x="0.0" y="0.0" width="730" height="66"/>
@@ -1947,7 +1947,7 @@
                             <tableViewSection headerTitle="Services" id="Oi2-SE-DcW">
                                 <cells>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="Cell" textLabel="fV7-sD-Mxl" detailTextLabel="g7o-mr-G5l" style="IBUITableViewCellStyleValue1" id="qwj-oV-YgU">
-                                        <rect key="frame" x="0.0" y="1026" width="730" height="66"/>
+                                        <rect key="frame" x="110" y="1026" width="730" height="66"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="qwj-oV-YgU" id="S07-eB-z3r">
                                             <rect key="frame" x="0.0" y="0.0" width="730" height="66"/>
@@ -1975,7 +1975,7 @@
                             <tableViewSection headerTitle="Info" id="8bN-Fj-ZwM">
                                 <cells>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="Cell" textLabel="rrQ-1r-aq3" detailTextLabel="JIK-nm-s5r" style="IBUITableViewCellStyleValue1" id="2jx-XN-Qib">
-                                        <rect key="frame" x="0.0" y="1219" width="730" height="66"/>
+                                        <rect key="frame" x="110" y="1219" width="730" height="66"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="2jx-XN-Qib" id="WOA-de-ljF">
                                             <rect key="frame" x="0.0" y="0.0" width="730" height="66"/>
@@ -1999,7 +1999,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="Cell" textLabel="fpb-Vv-rCp" detailTextLabel="hRz-9h-nvi" style="IBUITableViewCellStyleValue1" id="X94-bg-7gt">
-                                        <rect key="frame" x="0.0" y="1299" width="730" height="66"/>
+                                        <rect key="frame" x="110" y="1299" width="730" height="66"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="X94-bg-7gt" id="G4x-PN-QWu">
                                             <rect key="frame" x="0.0" y="0.0" width="730" height="66"/>
@@ -2023,7 +2023,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="Cell" textLabel="3rl-cy-Kkl" detailTextLabel="Yqn-vd-AJJ" style="IBUITableViewCellStyleValue1" id="WnD-9g-uzC">
-                                        <rect key="frame" x="0.0" y="1379" width="730" height="66"/>
+                                        <rect key="frame" x="110" y="1379" width="730" height="66"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="WnD-9g-uzC" id="FBP-Gv-gjG">
                                             <rect key="frame" x="0.0" y="0.0" width="730" height="66"/>
@@ -2169,18 +2169,24 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Episode Placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="xvK-RF-4sr">
-                                <rect key="frame" x="0.0" y="0.0" width="1920" height="1020"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1920" height="1080"/>
                             </imageView>
                             <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AEB-Li-lg8">
-                                <rect key="frame" x="0.0" y="0.0" width="1920" height="1020"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1920" height="1080"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="IRt-S2-fMs">
-                                    <rect key="frame" x="0.0" y="0.0" width="1920" height="1020"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="1920" height="1080"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 </view>
                                 <blurEffect style="regular"/>
                             </visualEffectView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7gy-xF-xUH">
+                                <rect key="frame" x="106" y="205" width="158" height="90"/>
+                                <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="75"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="95" sectionHeaderHeight="7" sectionFooterHeight="7" translatesAutoresizingMaskIntoConstraints="NO" id="dAV-KT-7dh">
-                                <rect key="frame" x="100" y="205" width="956" height="815"/>
+                                <rect key="frame" x="100" y="295" width="956" height="725"/>
                                 <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="cell" id="wy0-bN-qn6" customClass="DownloadDetailTableViewCell" customModule="PopcornTime" customModuleProvider="target">
@@ -2275,44 +2281,27 @@
                             <constraint firstItem="dAV-KT-7dh" firstAttribute="trailing" secondItem="phA-Jf-OOO" secondAttribute="centerX" multiplier="1.1" id="4PH-m0-RaQ"/>
                             <constraint firstAttribute="trailing" secondItem="9FJ-hH-1nE" secondAttribute="trailing" constant="100" id="8VH-ee-MlG"/>
                             <constraint firstAttribute="bottomMargin" secondItem="dAV-KT-7dh" secondAttribute="bottom" id="8mP-5Z-eR1"/>
-                            <constraint firstAttribute="bottomMargin" secondItem="xvK-RF-4sr" secondAttribute="bottom" id="Faa-rk-16C"/>
+                            <constraint firstAttribute="bottom" secondItem="xvK-RF-4sr" secondAttribute="bottom" id="Faa-rk-16C"/>
                             <constraint firstItem="9FJ-hH-1nE" firstAttribute="centerY" secondItem="phA-Jf-OOO" secondAttribute="centerY" id="HEm-g3-Ahp"/>
-                            <constraint firstItem="dAV-KT-7dh" firstAttribute="top" secondItem="qNp-eR-qUr" secondAttribute="bottom" id="MOj-PM-Tjn"/>
                             <constraint firstItem="9FJ-hH-1nE" firstAttribute="centerX" secondItem="XKH-az-gnC" secondAttribute="trailing" constant="12" id="N6g-Bt-5mK"/>
                             <constraint firstItem="dAV-KT-7dh" firstAttribute="leading" secondItem="phA-Jf-OOO" secondAttribute="leading" constant="100" id="RXU-LZ-gjO"/>
                             <constraint firstItem="xvK-RF-4sr" firstAttribute="top" secondItem="phA-Jf-OOO" secondAttribute="top" id="Skf-Qh-RME"/>
+                            <constraint firstItem="9FJ-hH-1nE" firstAttribute="top" relation="greaterThanOrEqual" secondItem="7gy-xF-xUH" secondAttribute="bottom" constant="50" id="XAq-7m-epn"/>
                             <constraint firstItem="xvK-RF-4sr" firstAttribute="leading" secondItem="phA-Jf-OOO" secondAttribute="leading" id="ZV6-ia-fR7"/>
                             <constraint firstItem="AEB-Li-lg8" firstAttribute="bottom" secondItem="xvK-RF-4sr" secondAttribute="bottom" id="ZlY-n3-PQn"/>
                             <constraint firstItem="9SM-aI-AHA" firstAttribute="top" secondItem="XKH-az-gnC" secondAttribute="top" id="adE-7E-bDJ"/>
                             <constraint firstItem="9FJ-hH-1nE" firstAttribute="leading" secondItem="dAV-KT-7dh" secondAttribute="trailing" constant="100" id="dc4-fd-dnk"/>
+                            <constraint firstItem="7gy-xF-xUH" firstAttribute="top" secondItem="qNp-eR-qUr" secondAttribute="bottom" id="g5I-L5-v5a"/>
+                            <constraint firstItem="7gy-xF-xUH" firstAttribute="leading" secondItem="phA-Jf-OOO" secondAttribute="leadingMargin" id="hsJ-qs-58d"/>
+                            <constraint firstItem="dAV-KT-7dh" firstAttribute="top" secondItem="7gy-xF-xUH" secondAttribute="bottom" id="kYJ-Ua-CQY"/>
                             <constraint firstItem="9SM-aI-AHA" firstAttribute="leading" secondItem="9FJ-hH-1nE" secondAttribute="centerX" constant="12" id="kal-ZH-Uwc"/>
                             <constraint firstItem="XKH-az-gnC" firstAttribute="top" secondItem="9FJ-hH-1nE" secondAttribute="bottom" constant="40" id="mcN-Cp-Qgh"/>
                             <constraint firstAttribute="trailing" secondItem="xvK-RF-4sr" secondAttribute="trailing" id="o5b-uh-gIf"/>
                             <constraint firstItem="AEB-Li-lg8" firstAttribute="leading" secondItem="xvK-RF-4sr" secondAttribute="leading" id="pSa-lO-9O7"/>
+                            <constraint firstAttribute="trailingMargin" relation="greaterThanOrEqual" secondItem="7gy-xF-xUH" secondAttribute="trailing" id="s4K-Ph-PIp"/>
                             <constraint firstItem="AEB-Li-lg8" firstAttribute="trailing" secondItem="xvK-RF-4sr" secondAttribute="trailing" id="yer-vW-hOg"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="aDA-Ig-9PE">
-                        <barButtonItem key="leftBarButtonItem" id="2WH-Wa-vU6">
-                            <view key="customView" contentMode="scaleToFill" id="YoN-zw-yU0">
-                                <rect key="frame" x="90" y="44" width="426" height="108"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7gy-xF-xUH">
-                                        <rect key="frame" x="0.0" y="0.0" width="158" height="90"/>
-                                        <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="75"/>
-                                        <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                </subviews>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                <constraints>
-                                    <constraint firstItem="7gy-xF-xUH" firstAttribute="top" secondItem="YoN-zw-yU0" secondAttribute="top" id="6SI-U8-sBe"/>
-                                    <constraint firstItem="7gy-xF-xUH" firstAttribute="leading" secondItem="YoN-zw-yU0" secondAttribute="leading" id="gCY-EL-Rpu"/>
-                                </constraints>
-                            </view>
-                        </barButtonItem>
-                    </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <connections>
                         <outlet property="backgroundImageView" destination="xvK-RF-4sr" id="Ugg-w1-G59"/>
@@ -2888,14 +2877,14 @@
                             <visualEffectView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iua-MW-1zL">
                                 <rect key="frame" x="0.0" y="0.0" width="1920" height="1080"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" id="4bM-gn-0es">
+                                <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="4bM-gn-0es">
                                     <rect key="frame" x="0.0" y="0.0" width="1920" height="1080"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <visualEffectView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="87j-Ts-eJr">
                                             <rect key="frame" x="0.0" y="0.0" width="1920" height="1080"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" id="3wU-Ay-4sc">
+                                            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="3wU-Ay-4sc">
                                                 <rect key="frame" x="0.0" y="0.0" width="1920" height="1080"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>


### PR DESCRIPTION
Apple TV's Download Details screen has some layout position issues.

![before](https://user-images.githubusercontent.com/15235260/85954906-3b80ae80-b951-11ea-8733-6dc8f8588df5.png)

This PR fixes the extra margin space on background image bottom constraint and title hidden behind the tab bar issues.

![after](https://user-images.githubusercontent.com/15235260/85954895-2d329280-b951-11ea-9a64-c03260cdeed5.png)