### PR TITLE
[WIP] iOS 14 fix

### DIFF
--- a/PopcornTime/Supporting Files/iOS.plist
+++ b/PopcornTime/Supporting Files/iOS.plist
@@ -119,5 +119,7 @@
 			</dict>
 		</dict>
 	</array>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Needed for Airplay &amp; Chromecast</string>
 </dict>
 </plist>


### PR DESCRIPTION
Gets the app running again, but very limited in functionality
Currently can only play external torrents, or completed downloads (avoiding quality selection)
Disabling quality selector doesn't seem to help (as worked previously with a similar issue)
Suspect UI issue due to segue changes. Have tried switching loader to modal, but still no dice